### PR TITLE
Add basic support for other shelr.tv instances

### DIFF
--- a/bin/shelr
+++ b/bin/shelr
@@ -37,7 +37,7 @@ HELP     = <<-HELP
 
     Setup:
 
-      setup API_KEY   - set your API key
+      setup API_KEY [API_URL] - set your API key and API site
       backend [ttyrec|script] - setup recorder backend
 
     Visit: http://shelr.tv/ for more info.
@@ -85,6 +85,9 @@ when 'push'
     puts "Select one..."
   end
 when 'setup'
+  if ARGV[2]
+    Shelr.api_url = ARGV[2]
+  end
   if ARGV[1]
     Shelr.api_key = ARGV[1]
   else

--- a/lib/shelr.rb
+++ b/lib/shelr.rb
@@ -4,12 +4,12 @@ require 'json'
 module Shelr
 
   APP_NAME       = 'shelr'
-  API_URL        = ENV['SHELR_LOCAL'] ? 'http://localhost:3000' : 'http://shelr.tv'
   XDG_DATA_DIR   = ENV['XDG_DATA_HOME']   || File.join(ENV['HOME'], '.local', 'share')
   XDG_CONFIG_DIR = ENV['XDG_CONFIG_HOME'] || File.join(ENV['HOME'], '.config')
   DATA_DIR       = File.join(XDG_DATA_DIR,   APP_NAME)
   CONFIG_DIR     = File.join(XDG_CONFIG_DIR, APP_NAME)
   API_KEY_CFG    = File.join(CONFIG_DIR, 'api_key')
+  API_URL_CFG    = File.join(CONFIG_DIR, 'api_url')
   BACKEND_CFG    = File.join(CONFIG_DIR, 'backend')
 
   autoload :Recorder,  'shelr/recorder.rb'
@@ -28,6 +28,16 @@ module Shelr
     def api_key=(key)
       ensure_config_dir_exist
       File.open(API_KEY_CFG, 'w+') { |f| f.puts(key.strip) }
+    end
+
+    def api_url
+      return ENV['SHELR_LOCAL'] ? 'http://localhost:3000' : 'http://shelr.tv' unless File.exist?(API_URL_CFG)
+      @api_url ||= File.read(API_URL_CFG).strip
+    end
+
+    def api_url=(url)
+      ensure_config_dir_exist
+      File.open(API_URL_CFG, 'w+') { |f| f.puts(url.strip) }
     end
 
     def backend

--- a/lib/shelr/publisher.rb
+++ b/lib/shelr/publisher.rb
@@ -8,7 +8,7 @@ module Shelr
       @private = priv
       ensure_unlocked(id)
       with_exception_handler do
-        uri = URI.parse(Shelr::API_URL + '/records')
+        uri = URI.parse(Shelr.api_url + '/records')
         params = { 'record' => prepare(id) }
         params.merge!({'api_key' => Shelr.api_key}) if api_key
         handle_response Net::HTTP.post_form(uri, params)


### PR DESCRIPTION
This is a change to the setup command:

``` bash
shelr setup API_KEY [API_URL]
```
